### PR TITLE
fix: saudi iban only with digits

### DIFF
--- a/src/bbanStructure.ts
+++ b/src/bbanStructure.ts
@@ -758,7 +758,7 @@ export class BbanStructure {
 
     [CountryCode.SA]: new BbanStructure(
       BbanStructurePart.bankCode(2, CharacterType.n),
-      BbanStructurePart.accountNumber(18, CharacterType.c),
+      BbanStructurePart.accountNumber(18, CharacterType.n),
     ),
 
     [CountryCode.SC]: new BbanStructure(


### PR DESCRIPTION
This PR aims to fix the Saudi IBAN which is only with digits in account number.

https://www.iban.com/structure

<img width="1039" alt="Screen Shot 2021-07-27 at 1 25 50 PM" src="https://user-images.githubusercontent.com/7845001/127146093-dde47c40-48d6-4b4a-ab99-3c65019db62b.png">
