### PR TITLE
fix(MU): account number is numeric (12!n) per ISO 13616

### DIFF
--- a/src/bbanStructure.ts
+++ b/src/bbanStructure.ts
@@ -584,7 +584,7 @@ export class BbanStructure {
     [CountryCode.MU]: new BbanStructure(
       BbanStructurePart.bankCode(6, CharacterType.c), // 4!a2!n
       BbanStructurePart.branchCode(2, CharacterType.n),
-      BbanStructurePart.accountNumber(12, CharacterType.c),
+      BbanStructurePart.accountNumber(12, CharacterType.n),
       BbanStructurePart.accountType(3, CharacterType.n),
       BbanStructurePart.currencyType(3, CharacterType.a),
     ),

--- a/test/iban.spec.ts
+++ b/test/iban.spec.ts
@@ -11,6 +11,14 @@ describe("IBAN", () => {
     it("bad iban", () => {
       expect(IBAN.isValid("BA391990440001200278")).toBe(false);
     });
+    it("MU account number must be numeric (12!n)", () => {
+      // SWIFT IBAN Registry MU BBAN structure is 4!a2!n2!n12!n3!n3!a; the
+      // account number is 12 digits. A letter in that field is structurally
+      // invalid even when the check digits are correct (mod-97 == 1 here).
+      expect(IBAN.isValid("MU84BOMM010110103030020A000MUR")).toBe(false);
+      // Genuine registry example stays valid.
+      expect(IBAN.isValid("MU17BOMM0101101030300200000MUR")).toBe(true);
+    });
   });
 
   describe("Test check digit", () => {


### PR DESCRIPTION
The SWIFT IBAN Registry BBAN structure for Mauritius is `4!a2!n2!n12!n3!n3!a`, so the 12-character account number is digits only. In `bbanStructure.ts` it was declared `accountNumber(12, CharacterType.c)` (alphanumeric) — while the inline comment on the same entry already records the spec as `12!n`.

Because of the wider character class, an IBAN with a letter in the account-number field validated as `true` even though it is structurally invalid:

```js
import { IBAN } from "ibankit";

// "A" sits in the 12!n account-number field; check digits are correct (mod-97 == 1)
IBAN.isValid("MU84BOMM010110103030020A000MUR"); // before: true  -> after: false

// genuine registry example is unaffected
IBAN.isValid("MU17BOMM0101101030300200000MUR"); // true
```

For reference, `ibantools.isValidIBAN` rejects the first string.

The fix narrows the account-number class to `CharacterType.n`. The leading `4!a2!n` bank group is left as the existing `6` alphanumeric superset, since a single structure part cannot express that mixed group; this change is scoped to the confirmed `12!n` violation.

Added a regression test next to the existing `IBAN.isValid` cases. Full suite green (143 tests).