### PR TITLE
fix: keep printFormat from emitting a trailing separator

### DIFF
--- a/src/ibanUtil.ts
+++ b/src/ibanUtil.ts
@@ -274,7 +274,7 @@ export function replaceCheckDigit(iban: string, checkDigit: string): string {
  * @return A string representing formatted Iban for printing.
  */
 export function toFormattedString(iban: string, separator: string = " "): string {
-  return iban.replace(/(.{4})/g, `$1${separator}`).trim();
+  return iban.replace(/(.{4})(?!$)/g, `$1${separator}`).trim();
 }
 
 /* Returns formatted version of BBAN from IBAN.

--- a/test/iban.spec.ts
+++ b/test/iban.spec.ts
@@ -886,6 +886,10 @@ describe("IBAN", () => {
       expect(IBAN.printFormat("FR1420041010050500013M02606")).toBe("FR14 2004 1010 0505 0001 3M02 606");
     });
 
+    it("printFormat with a non-space separator", () => {
+      expect(IBAN.printFormat("BE68539007547034", "-")).toBe("BE68-5390-0754-7034");
+    });
+
     it("electronicFormat", () => {
       expect(IBAN.electronicFormat(" FR14*2&004 1010050500013M02606*")).toBe("FR1420041010050500013M02606");
     });


### PR DESCRIPTION
`toFormattedString` appends the separator after every 4-character group with `/(.{4})/g` and then calls `.trim()` to remove the one left dangling after the final group. `.trim()` only strips whitespace, so that cleanup silently fails for any non-space separator whenever the IBAN length is a multiple of 4.

`IBAN.printFormat` exposes the separator argument, so:

```js
IBAN.printFormat("BE68539007547034", "-")  // BE = 16 chars
// returns "BE68-5390-0754-7034-"   (trailing dash)
// expected "BE68-5390-0754-7034"
```

This affects every country whose IBAN length is divisible by 4 (BE, AD, and others). The default space separator is unaffected because `.trim()` happens to clean it up.

Fix: anchor the group match with a negative lookahead `/(.{4})(?!$)/g` so no separator is emitted after the last group. This is the approach `iban.js` uses in `printFormat`, which this method documents itself as compatible with. The default-separator output is unchanged.

Adds a regression test for a non-space separator.
